### PR TITLE
Updated rollup wrapper to pass through all options by default

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28,7 +28,7 @@ function rollupStream(options, bundleCb) {
 		return resolveJs(rootDir, id);
 	}
 	return through2.obj(function (file, enc, callback) {
-		var thisOptions = {};
+		var thisOptions = Object.assign({}, options);
 		thisOptions.cache = cache;
 		thisOptions.entry = file.path;
 		thisOptions.plugins = [memory({ contents: file.contents.toString() })].concat(options.plugins || []).concat({ resolveId: resolveId });

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function rollupStream( options, bundleCb ) {
 		return resolveJs( rootDir, id );
 	}
 	return through2.obj( function( file, enc, callback ) {
-		const thisOptions = {};
+		const thisOptions = Object.assign({}, options);
 		thisOptions.cache = cache;
 		thisOptions.entry = file.path;
 		thisOptions.plugins = [ memory({contents: file.contents.toString()}) ]


### PR DESCRIPTION
With this pull request, all options will be passed through to Rollup by default.

This allows users to pass through any valid option and not just the ones specifically supported by gulp-rollup-stream.